### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,6 @@
-AccessEvent KEYWORD1
-EventList   KEYWORD1
+AccessEvent	KEYWORD1
+EventList	KEYWORD1
 
-getListSize KEYWORD2
-getEvent    KEYWORD2
-addEvent    KEYWORD2
+getListSize	KEYWORD2
+getEvent	KEYWORD2
+addEvent	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords